### PR TITLE
fixed the app logo when starting application

### DIFF
--- a/nomad_camels/CAMELS_start.py
+++ b/nomad_camels/CAMELS_start.py
@@ -41,7 +41,7 @@ class LoadingScreen(QDialog):
         # Set custom window flags to disable some default decorations
         self.setWindowFlags(Qt.CustomizeWindowHint | Qt.WindowTitleHint)
         # Set the window icon using a resource from the graphics package
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
 
         # Load and set the image on the loading screen
         image = QPixmap()
@@ -153,7 +153,7 @@ def start_camels(start_proxy_bool=True):
     if app is None:
         # sys.argv += ['-platform', 'windows:darkmode=1']
         app = QApplication(sys.argv)
-    app.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+    app.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
 
     # Create and display the loading screen
     loading_screen = LoadingScreen()

--- a/nomad_camels/MainApp_v2.py
+++ b/nomad_camels/MainApp_v2.py
@@ -104,7 +104,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         self.setWindowTitle(
             "NOMAD CAMELS - Configurable Application for Measurements, Experiments and Laboratory-Systems"
         )
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
 
         # Set the logo image
         image = QPixmap()

--- a/nomad_camels/bluesky_handling/helper_functions.py
+++ b/nomad_camels/bluesky_handling/helper_functions.py
@@ -1344,7 +1344,7 @@ class Commenting_Box(QWidget):
         self.comment_box = TimestampTextEdit()
         self.finished_box = QCheckBox("commenting finished")
         self.setWindowTitle("Live Measurement Comments - NOMAD CAMELS")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
         layout.addWidget(self.comment_box, 0, 0)
         layout.addWidget(self.finished_box, 1, 0)
         self.setLayout(layout)

--- a/nomad_camels/frontpanels/protocol_config.py
+++ b/nomad_camels/frontpanels/protocol_config.py
@@ -125,7 +125,7 @@ class Protocol_Config(Ui_Protocol_View, QWidget):
             self.old_name = protocol.name
         self.setupUi(self)
         self.setWindowTitle(f"{protocol.name} - Measurement Protocol - NOMAD CAMELS")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
         self.configuration_main_widget.setHidden(True)
         self.general_settings = General_Protocol_Settings(protocol=protocol)
 

--- a/nomad_camels/main_classes/list_plot.py
+++ b/nomad_camels/main_classes/list_plot.py
@@ -60,7 +60,7 @@ class Values_List_Plot(QWidget):
             self.setWindowTitle(f"{value_list[0]} ...")
         else:
             self.setWindowTitle("Current Value List")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
         self.stream_name = stream_name
         place_widget(self, top_left_x, top_left_y, plot_width, plot_height)
 

--- a/nomad_camels/main_classes/manual_control.py
+++ b/nomad_camels/main_classes/manual_control.py
@@ -46,7 +46,7 @@ class Manual_Control(QWidget):
         self.control_data = control_data or {}
 
         self.setWindowTitle(f"{title} - NOMAD CAMELS")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
         self.name = title
         self.device = None
         self.ophyd_device = None

--- a/nomad_camels/main_classes/plot_2D.py
+++ b/nomad_camels/main_classes/plot_2D.py
@@ -89,7 +89,7 @@ class PlotWidget_2D(QWidget):
         self.setLayout(layout)
 
         self.setWindowTitle(title or f"{z_name} 2D")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
         place_widget(self)
 
     def autoscale(self):

--- a/nomad_camels/main_classes/plot_pyqtgraph.py
+++ b/nomad_camels/main_classes/plot_pyqtgraph.py
@@ -298,7 +298,7 @@ class PlotWidget(QWidget):
         self.liveFitPlots = []
         self.ax2_viewbox = None
         self.setWindowTitle(title or f"{x_name} vs. {y_names[0]}")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
 
         ax2 = None
         plotItem = self.plot_widget.getPlotItem()
@@ -1220,7 +1220,7 @@ class PlotWidget_2D(QWidget):
         self.setWindowTitle(
             title or f"{zlabel or z_name} vs. {xlabel or x_name}, {ylabel or y_name}"
         )
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
         self.graphics_layout = pg.GraphicsLayoutWidget()
         self.plot = self.graphics_layout.addPlot(col=0, row=0)
         self.x_name = x_name

--- a/nomad_camels/main_classes/plot_widget.py
+++ b/nomad_camels/main_classes/plot_widget.py
@@ -295,7 +295,7 @@ class PlotWidget(QWidget):
         self.setLayout(layout)
 
         self.setWindowTitle(title or f"{x_name} vs. {y_names[0]}")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
 
         self.plot_options.hide()
         self.options_open = False
@@ -1461,7 +1461,7 @@ class PlotWidget_NoBluesky(QWidget):
         self.change_maxlen()
 
         self.setWindowTitle(title or f"{xlabel} vs. {ylabel}")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
 
         layout = QGridLayout()
         layout.addWidget(canvas, 0, 1, 1, 6)

--- a/nomad_camels/tools/EPICS_driver_builder.py
+++ b/nomad_camels/tools/EPICS_driver_builder.py
@@ -26,7 +26,7 @@ class EPICS_Driver_Builder(QDialog):
 
         try:
             self.setWindowIcon(
-                QIcon(str(resources.files(graphics) / "camels_icon.png"))
+                QIcon(str(resources.files(graphics) / "CAMELS_Icon.png"))
             )
         except:
             pass

--- a/nomad_camels/tools/device_driver_builder.py
+++ b/nomad_camels/tools/device_driver_builder.py
@@ -32,7 +32,7 @@ class Driver_Builder(Ui_VISA_Device_Builder, QDialog):
 
         try:
             self.setWindowIcon(
-                QIcon(str(resources.files(graphics) / "camels_icon.png"))
+                QIcon(str(resources.files(graphics) / "CAMELS_Icon.png"))
             )
         except:
             pass

--- a/nomad_camels/ui_widgets/variable_table.py
+++ b/nomad_camels/ui_widgets/variable_table.py
@@ -118,7 +118,7 @@ class VariableBox(QWidget):
         super().__init__(parent)
         name = name or (protocol.name if protocol else "protocol")
         self.setWindowTitle(f"Live variable control - {name} - NOMAD CAMELS")
-        self.setWindowIcon(QIcon(str(resources.files(graphics) / "camels_icon.png")))
+        self.setWindowIcon(QIcon(str(resources.files(graphics) / "CAMELS_Icon.png")))
         self.layout = QVBoxLayout()
         self.setLayout(self.layout)
         self.table = VariableTable(

--- a/nomad_camels/utility/update_camels.py
+++ b/nomad_camels/utility/update_camels.py
@@ -188,7 +188,7 @@ def show_release_notes():
         def __init__(self, markdown_text):
             super().__init__()
             self.setWindowTitle("Changelog - NOMAD CAMELS")
-            self.setWindowIcon(QIcon(str(importlib.resources.files(graphics) / "camels_icon.png")))
+            self.setWindowIcon(QIcon(str(importlib.resources.files(graphics) / "CAMELS_Icon.png")))
 
             layout = QGridLayout(self)
 


### PR DESCRIPTION
This PR fixes the issue #153  where the nomad-camels application window icon is not displayed correctly when launched via nomad-camels. The problem was caused by:

A case mismatch between the filename (CAMELS_Icon.png) and its usage in code.

The icon file not being included in the package during installation.

Updated all references to the new filename

find nomad_camels/ -type f -name "*.py" -exec sed -i 's/camels_icon\.png/CAMELS_Icon.png/g' {} +

It was strange to see mismatch in the names. 