### PR TITLE
Update to version 1.10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Please also see our publication in the Journal of Open Source Software (JOSS):
 Fixes:
 - Fixed variables of the protocol not always appearing and being saved. 
 - Updated the suitcase-nomad-camels dependency to 1.3.2: Fixes broken saving of plots to the final data file. Now correctly deals with `numpy` and `const` functions used.
+- Replaced `pkg_resources` with `importlib.metadata` to get the installed version of CAMELS, as the former is deprecated. Now runs with new versions of `setuptools`.
 
 ### 1.10.8
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Please also see our publication in the Journal of Open Source Software (JOSS):
 
 # Changelog
 
+### 1.10.9
+Fixes:
+- Fixed variables of the protocol not always appearing and being saved. 
+- Updated the suitcase-nomad-camels dependency to 1.3.2: Fixes broken saving of plots to the final data file. Now correctly deals with `numpy` and `const` functions used.
+
 ### 1.10.8
 
 Changes:

--- a/nomad_camels/bluesky_handling/protocol_builder.py
+++ b/nomad_camels/bluesky_handling/protocol_builder.py
@@ -328,7 +328,12 @@ def build_protocol(
             continue
         variable_string += f"{var} = {val}\n"
         variable_string += f'namespace["{var}"] = {var}\n'
-    for var, val in protocol.loop_step_variables.items():
+    if not variables_handling.loop_step_variables:
+        try:
+            protocol.update_variables()
+        except Exception as e:
+            print(f"Failed to update the variables. The protocol might not work as intended!\n{e}")
+    for var, val in variables_handling.loop_step_variables.items():
         if variables_handling.check_data_type(val) == "String":
             val = f'"{val}"'
         if "(" in var or ")" in var:

--- a/nomad_camels/utility/update_camels.py
+++ b/nomad_camels/utility/update_camels.py
@@ -23,15 +23,16 @@ from PySide6.QtGui import QIcon
 
 
 def get_version():
-    """checks the installed version of nomad-camels and returns it."""
+    """Checks the installed version of nomad-camels and returns it."""
     try:
-        import pkg_resources
-
-        return pkg_resources.get_distribution("nomad-camels").version
-    except (AttributeError, pkg_resources.DistributionNotFound):
+        from importlib.metadata import version, PackageNotFoundError
+        return version("nomad-camels")
+    except PackageNotFoundError:
+        # Fallback for when the package is run locally without being 'installed'
         try:
+            import nomad_camels
             return nomad_camels.__version__
-        except Exception:
+        except (ImportError, AttributeError):
             return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nomad_camels"
-version = "1.10.8"
+version = "1.10.9"
 description = "CAMELS is a configurable measurement software, targeted towards the requirements of experimental solid-state physics."
 authors = [
     {name = "FAIRmat - HU Berlin",email = "nomad-camels@fau.de"}
@@ -18,7 +18,7 @@ pyside6 = ">=6.6.0,<6.9"
 bluesky = ">=1.9.0"
 ophyd = ">=1.6.4"
 lmfit = ">=1.3.0"
-suitcase-nomad-camels-hdf5 = ">=1.3.1"
+suitcase-nomad-camels-hdf5 = ">=1.3.2"
 databroker = ">=1.2.5, <2.0.0"
 matplotlib = ">=3.6.2"
 pyqtgraph = ">=0.13.3"


### PR DESCRIPTION
### 1.10.9
Fixes:
- Fixed variables of the protocol not always appearing and being saved. 
- Updated the suitcase-nomad-camels dependency to 1.3.2: Fixes broken saving of plots to the final data file. Now correctly deals with `numpy` and `const` functions used.
- Replaced `pkg_resources` with `importlib.metadata` to get the installed version of CAMELS, as the former is deprecated. Now runs with new versions of `setuptools`.