### PR TITLE
Update to 1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Please also see our publication in the Journal of Open Source Software (JOSS):
 
 # Changelog
 
+### 1.11.0
+
+Fixes:
+- Removed deprecated calls to `bluesky.callbacks.zmq` that broke installs when using `bluesky > 1.15.1`. Replaced with a new and cleaner implementation of the ZMQ proxy. Cleanup is also improved. ZMQ implementation for testing was adapted accordingly.
+
 ### 1.10.9
 Fixes:
 - Fixed variables of the protocol not always appearing and being saved. 

--- a/nomad_camels/MainApp_v2.py
+++ b/nomad_camels/MainApp_v2.py
@@ -307,46 +307,42 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             self.preferences["last_shown_notes"] = version
             load_save_functions.save_preferences(self.preferences)
         if start_proxy_bool:
-            # Setup a single ZMQ proxy, dispatcher and publisher for all plots
-            from bluesky.callbacks.zmq import RemoteDispatcher, Publisher
-            from nomad_camels.main_classes.plot_proxy import StoppableProxy as Proxy
-            from threading import Thread
-            from zmq.error import ZMQError
+            from nomad_camels.main_classes.plot_proxy import run_zmq_proxy
+            import multiprocessing
+            import threading
             import asyncio
+            from bluesky.callbacks.zmq import RemoteDispatcher, Publisher
 
+            # Apply Windows asyncio fix (prevents the ProactorEventLoop warning)
             if sys.platform == "win32":
                 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+            # Setup queue to receive dynamic ports
+            port_queue = multiprocessing.Queue()
+            # Start the Proxy Process
+            # We store it as self.proxy_proc so we can terminate it later
+            self.proxy_proc = multiprocessing.Process(
+                target=run_zmq_proxy,
+                args=(port_queue,),
+                daemon=True,
+            )
+            self.proxy_proc.start()
+            # Give the proxy 200ms to bind to the ports
+            time.sleep(0.2)
+            # Retrieve the dynamically assigned ports
+            in_port, out_port = port_queue.get()
+            print(f"Proxy started on ports: Publisher={in_port}, Dispatcher={out_port}")
+            # Setup Publisher and Dispatcher using the dynamic ports once for all plots and measurements run from the main app.
+            # Measurements only create their own if the Python script is run 'standalone', so without the main app.
+            self.publisher = Publisher(f"localhost:{in_port}")
+            self.dispatcher = RemoteDispatcher(f"localhost:{out_port}")
 
-            def setup_threads():
-                try:
-                    proxy = Proxy(5577, 5578)
-                    proxy_created = True
-                except ZMQError as e:
-                    # If the proxy is already running, a ZMQError will be raised.
-                    proxy = None  # We will use the already running proxy.
-                    proxy_created = False
-
-                def start_proxy():
-                    if proxy_created and proxy is not None:
-                        proxy.start()
-
-                dispatcher = RemoteDispatcher("localhost:5578")
-
-                def start_dispatcher():
-                    try:
-                        dispatcher.start()
-                    except asyncio.exceptions.CancelledError:
-                        # This error is raised when the dispatcher is stopped. It can therefore be ignored
-                        pass
-
-                return proxy, dispatcher, start_proxy, start_dispatcher
-
-            self.publisher = Publisher("localhost:5577")
-            self.proxy, self.dispatcher, start_proxy, start_dispatcher = setup_threads()
-            proxy_thread = Thread(target=start_proxy, daemon=True)
-            dispatcher_thread = Thread(target=start_dispatcher, daemon=True)
-            proxy_thread.start()
-            dispatcher_thread.start()
+            # 4. Start Dispatcher in a Thread
+            # We store the thread as self.dispatcher_thread to join it later
+            self.dispatcher_thread = threading.Thread(
+                target=self.dispatcher.start,
+                daemon=True,
+            )
+            self.dispatcher_thread.start()
 
     def add_tag(self):
         """
@@ -770,8 +766,18 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         Args:
             a0 (QCloseEvent): The close event.
         """
-        if hasattr(self, "proxy") and self.proxy is not None:
-            self.proxy.stop()
+        # Clean up ZMQ infrastructure
+        # Stop the dispatcher thread gracefully
+        if hasattr(self, "dispatcher") and self.dispatcher is not None:
+            self.dispatcher.stop()
+            # If you stored the thread, join it to ensure it finishes
+            if hasattr(self, "dispatcher_thread") and self.dispatcher_thread.is_alive():
+                self.dispatcher_thread.join(timeout=1.0)
+
+        # Terminate the proxy process
+        if hasattr(self, "proxy_proc") and self.proxy_proc is not None:
+            self.proxy_proc.terminate()
+            self.proxy_proc.join(timeout=1.0)
         for window in list(self.open_windows):
             window.close()
         if self.open_windows:
@@ -2002,7 +2008,11 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         user = self.get_user_name_data()[0]
         sample, sampledata = self.get_sample_name_data(prompt_on_missing=False)
         protocol = self.protocols_dict[protocol_name]
-        session = (getattr(protocol, "session_name", None) or self.lineEdit_session.text() or "").strip()
+        session = (
+            getattr(protocol, "session_name", None)
+            or self.lineEdit_session.text()
+            or ""
+        ).strip()
         if protocol.use_nexus:
             file_ending = ".nxs"
         else:
@@ -2025,11 +2035,10 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         if not os.path.isdir(os.path.dirname(savepath)):
             os.makedirs(os.path.dirname(savepath))
         files = [
-                entry.path  # scandir entries already have a .path attribute
-                for entry in os.scandir(os.path.dirname(savepath))
-                if entry.is_file()
-                and entry.name.startswith(filename or "data")
-            ]
+            entry.path  # scandir entries already have a .path attribute
+            for entry in os.scandir(os.path.dirname(savepath))
+            if entry.is_file() and entry.name.startswith(filename or "data")
+        ]
         if files:
             savepath = max(files, key=os.path.getmtime)
         while not os.path.exists(savepath):
@@ -2120,7 +2129,9 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             self.pushButton_resume.setEnabled(False)
             self.pushButton_pause.setEnabled(False)
             self.pushButton_stop.setEnabled(True)
-            if not self.build_protocol(protocol_name, ask_file=False, variables=variables):
+            if not self.build_protocol(
+                protocol_name, ask_file=False, variables=variables
+            ):
                 self.setCursor(Qt.ArrowCursor)
                 self.button_area_meas.enable_run_buttons()
                 return
@@ -2663,11 +2674,13 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             device_handling.close_devices(for_close)
 
     def formatted_iso_time(self, timestamp=None):
-        start_time = datetime.fromtimestamp(timestamp, tz=datetime.now().astimezone().tzinfo)
+        start_time = datetime.fromtimestamp(
+            timestamp, tz=datetime.now().astimezone().tzinfo
+        )
         start_time_formatted = start_time.isoformat(timespec="seconds")
         start_time_formatted = start_time_formatted.replace(":", "-")
         return start_time_formatted
-        
+
     def build_protocol(self, protocol_name, ask_file=True, variables=None):
         """
         Build the protocol file for the specified protocol.
@@ -2714,15 +2727,16 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         filename = protocol.filename.format(
             sample=sample,
             sample_id=sampledata.get("sample_id", ""),
-            user=user, protocol=protocol_name,
+            user=user,
+            protocol=protocol_name,
             session=protocol.session_name,
-            time=self.formatted_iso_time(self._protocol_start_time)
+            time=self.formatted_iso_time(self._protocol_start_time),
         )
         session_name = (protocol.session_name or "").strip()
         parts = [self.preferences["meas_files_path"], user, sample]
         if session_name:
             parts.append(session_name)
-        filename = (filename or "data")
+        filename = filename or "data"
         filename = clean_filename(filename)
         savepath = os.path.join(*parts, filename)
         self.protocol_savepath = savepath
@@ -2805,7 +2819,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                         sampledata = self.sampledata[s]
                         break
             if not sampledata:
-                if  prompt_on_missing:
+                if prompt_on_missing:
                     # Create a popup window to warn the user that no sample was found and that "default sample" will be used
                     from PySide6.QtWidgets import QMessageBox
 

--- a/nomad_camels/bluesky_handling/protocol_builder.py
+++ b/nomad_camels/bluesky_handling/protocol_builder.py
@@ -143,45 +143,41 @@ standard_start_string += "\tbec = BestEffortCallback()\n"
 standard_start_string += "\tRE.subscribe(bec)\n"
 standard_start_string += """
     if not (dispatcher and publisher):
-        from bluesky.callbacks.zmq import RemoteDispatcher, Publisher
-        from nomad_camels.main_classes.plot_proxy import StoppableProxy as Proxy
-        from threading import Thread
-        from zmq.error import ZMQError
+        temp_dispatcher = True
+        from nomad_camels.main_classes.plot_proxy import run_zmq_proxy
+        import multiprocessing
+        import threading
         import asyncio
+        from bluesky.callbacks.zmq import RemoteDispatcher, Publisher
+
+        # Apply Windows asyncio fix (prevents the ProactorEventLoop warning)
         if sys.platform == "win32":
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        def setup_threads():
-            try:
-                proxy = Proxy(5577, 5578)
-                proxy_created = True
-            except ZMQError as e:
-                # If the proxy is already running, a ZMQError will be raised.
-                proxy = None  # We will use the already running proxy.
-                proxy_created = False
-            dispatcher = RemoteDispatcher("localhost:5578")
+        # Setup queue to receive dynamic ports
+        port_queue = multiprocessing.Queue()
+        # Start the Proxy Process
+        proxy_proc = multiprocessing.Process(
+            target=run_zmq_proxy,
+            args=(port_queue,),
+            daemon=True,
+        )
+        proxy_proc.start()
+        # Give the proxy 200ms to bind to the ports
+        time.sleep(0.2)
+        # Retrieve the dynamically assigned ports
+        in_port, out_port = port_queue.get()
+        print(f"Proxy started on ports: Publisher={in_port}, Dispatcher={out_port}")
+        # Setup Publisher and Dispatcher using the dynamic ports once for all plots and measurements run from the main app.
+        # Measurements only create their own if the Python script is run 'standalone', so without the main app.
+        publisher = Publisher(f"localhost:{in_port}")
+        dispatcher = RemoteDispatcher(f"localhost:{out_port}")
 
-            def start_proxy():
-                if proxy_created and proxy is not None:
-                    proxy.start()
-            
-            def start_dispatcher(plots, plots_plotly):
-                for plot in plots:
-                    dispatcher.subscribe(plot.livePlot)
-                for plotly_plot in plots_plotly:
-                    dispatcher.subscribe(plotly_plot)
-                try:
-                    dispatcher.start()
-                except asyncio.exceptions.CancelledError:
-                    # This error is raised when the dispatcher is stopped. It can therefore be ignored
-                    pass
-
-            return proxy, dispatcher, start_proxy, start_dispatcher
-        publisher = Publisher('localhost:5577')
-        publisher_subscription = RE.subscribe(publisher)
-        proxy, dispatcher, start_proxy, start_dispatcher = setup_threads()
-        proxy_thread = Thread(target=start_proxy, daemon=True)
-        dispatcher_thread = Thread(target=start_dispatcher, args=(plots, plots_plotly,), daemon=True)#
-        proxy_thread.start()
+        # 4. Start Dispatcher in a Thread
+        # We store the thread as dispatcher_thread to join it later
+        dispatcher_thread = threading.Thread(
+            target=dispatcher.start,
+            daemon=True,
+        )
         dispatcher_thread.start()
         time.sleep(0.5)
 """
@@ -303,14 +299,14 @@ def build_protocol(
     variable_string += f"export_to_csv = {protocol.export_csv}\n"
     variable_string += f"export_to_json = {protocol.export_json}\n"
     if "new_file_each_run" in variables_handling.preferences:
-        variable_string += f'new_file_each_run = {variables_handling.preferences["new_file_each_run"]}\n'
+        variable_string += f"new_file_each_run = {variables_handling.preferences['new_file_each_run']}\n"
     else:
         variable_string += f"new_file_each_run = False\n"
     if (
         "new_file_every_x_hours" in variables_handling.preferences
         and variables_handling.preferences["new_file_every_x_hours"]
     ):
-        variable_string += f'new_file_hours = {variables_handling.preferences["new_file_every_x_hours_value"]}\n'
+        variable_string += f"new_file_hours = {variables_handling.preferences['new_file_every_x_hours_value']}\n"
     else:
         variable_string += f"new_file_hours = 0\n"
     variable_string += f"do_nexus_output = {protocol.use_nexus}\n"
@@ -332,7 +328,9 @@ def build_protocol(
         try:
             protocol.update_variables()
         except Exception as e:
-            print(f"Failed to update the variables. The protocol might not work as intended!\n{e}")
+            print(
+                f"Failed to update the variables. The protocol might not work as intended!\n{e}"
+            )
     for var, val in variables_handling.loop_step_variables.items():
         if variables_handling.check_data_type(val) == "String":
             val = f'"{val}"'
@@ -619,7 +617,7 @@ def sub_protocol_string(
     for i, var in enumerate(variables_out["Variable"]):
         protocol_string += f'{tabs}namespace["{variables_out["Write to name"][i]}"] = {prot_name}_mod.namespace["{var}"]\n'
     protocol_string += f"{tabs}runEngine.unsubscribe(sub_eva_{prot_name})\n"
-    protocol_string += f'{tabs}yield from helper_functions.get_fit_results({prot_name}_mod.all_fits, namespace, True, {stream_str})\n'
+    protocol_string += f"{tabs}yield from helper_functions.get_fit_results({prot_name}_mod.all_fits, namespace, True, {stream_str})\n"
     return protocol_string
 
 

--- a/nomad_camels/bluesky_handling/protocol_builder.py
+++ b/nomad_camels/bluesky_handling/protocol_builder.py
@@ -143,7 +143,6 @@ standard_start_string += "\tbec = BestEffortCallback()\n"
 standard_start_string += "\tRE.subscribe(bec)\n"
 standard_start_string += """
     if not (dispatcher and publisher):
-        temp_dispatcher = True
         from nomad_camels.main_classes.plot_proxy import run_zmq_proxy
         import multiprocessing
         import threading

--- a/nomad_camels/main_classes/plot_proxy.py
+++ b/nomad_camels/main_classes/plot_proxy.py
@@ -1,4 +1,5 @@
 import threading
+import zmq
 from bluesky.callbacks.zmq import Proxy
 
 
@@ -14,8 +15,8 @@ class StoppableProxy(Proxy):
         self._stopped = False
 
         # Set LINGER to 0 to avoid blocking on socket close.
-        self._frontend.setsockopt(self.zmq.LINGER, 0)
-        self._backend.setsockopt(self.zmq.LINGER, 0)
+        self._frontend.setsockopt(zmq.LINGER, 0)
+        self._backend.setsockopt(zmq.LINGER, 0)
 
     def start(self):
         if self.closed:

--- a/nomad_camels/main_classes/plot_proxy.py
+++ b/nomad_camels/main_classes/plot_proxy.py
@@ -1,63 +1,29 @@
-import threading
-from bluesky.callbacks.zmq import Proxy
+import zmq
+import multiprocessing
 
-
-class StoppableProxy(Proxy):
+def run_zmq_proxy(queue: multiprocessing.Queue):
     """
-    A subclass of Proxy that runs in a background thread and provides a stop() method
-    to cleanly shut down the proxy.
+    Binds to port 0 (OS picks a free port) and returns the chosen ports
+    via the queue.
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._thread = None
-        self._stopped = False
-
-        # Set LINGER to 0 to avoid blocking on socket close.
-        self._frontend.setsockopt(self.zmq.LINGER, 0)
-        self._backend.setsockopt(self.zmq.LINGER, 0)
-
-    def start(self):
-        if self.closed:
-            raise RuntimeError(
-                "This Proxy has already been started and interrupted. "
-                "Create a fresh instance with {}".format(repr(self))
-            )
-        self._thread = threading.Thread(target=self._run, daemon=True)
-        self._thread.start()
-
-    def _run(self):
-        try:
-            # This call blocks until the context is terminated.
-            self.zmq.device(self.zmq.FORWARDER, self._frontend, self._backend)
-        except Exception:
-            # The device call will throw an exception when the context is terminated.
-            pass
-        finally:
-            self.closed = True
-            self._frontend.close()
-            self._backend.close()
-            # Only terminate the context here if stop() hasn't already done so.
-            if not self._stopped:
-                try:
-                    self._context.term()
-                except self.zmq.ZMQError as e:
-                    # Ignore the "Resource temporarily unavailable" error.
-                    if e.errno != self.zmq.EAGAIN:
-                        raise
-
-    def stop(self):
-        """
-        Stop the proxy by terminating the ZeroMQ context,
-        which interrupts the blocking device call.
-        """
-        if self.closed:
-            return
-        self._stopped = True
-        try:
-            self._context.term()
-        except self.zmq.ZMQError as e:
-            if e.errno != self.zmq.EAGAIN:
-                raise
-        if self._thread is not None:
-            self._thread.join()
+    context = zmq.Context.instance()
+    frontend = context.socket(zmq.SUB)
+    backend = context.socket(zmq.PUB)
+    
+    # Binding to port 0 lets the OS pick an available port
+    in_port = frontend.bind_to_random_port("tcp://*")
+    out_port = backend.bind_to_random_port("tcp://*")
+    
+    frontend.setsockopt_string(zmq.SUBSCRIBE, "")
+    
+    # Send the chosen ports back to the main process
+    queue.put((in_port, out_port))
+    
+    try:
+        zmq.proxy(frontend, backend)
+    except Exception:
+        pass
+    finally:
+        frontend.close()
+        backend.close()
+        context.term()

--- a/nomad_camels/main_classes/plot_proxy.py
+++ b/nomad_camels/main_classes/plot_proxy.py
@@ -1,5 +1,4 @@
 import threading
-import zmq
 from bluesky.callbacks.zmq import Proxy
 
 
@@ -15,8 +14,8 @@ class StoppableProxy(Proxy):
         self._stopped = False
 
         # Set LINGER to 0 to avoid blocking on socket close.
-        self._frontend.setsockopt(zmq.LINGER, 0)
-        self._backend.setsockopt(zmq.LINGER, 0)
+        self._frontend.setsockopt(self.zmq.LINGER, 0)
+        self._backend.setsockopt(self.zmq.LINGER, 0)
 
     def start(self):
         if self.closed:

--- a/nomad_camels/tests/protocol_test.py
+++ b/nomad_camels/tests/protocol_test.py
@@ -15,10 +15,12 @@ from threading import Thread
 import asyncio
 from zmq.error import ZMQError
 from bluesky.callbacks.zmq import RemoteDispatcher, Publisher
-from nomad_camels.main_classes.plot_proxy import StoppableProxy as Proxy
+from nomad_camels.main_classes.plot_proxy import run_zmq_proxy
 from nomad_camels.tests.test_helper_functions import ensure_demo_in_devices
-
+import multiprocessing
+import threading
 import socket
+import time
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -40,41 +42,70 @@ def zmq_setup():
     Yields a tuple (publisher, dispatcher) for use in tests.
     Stops the proxy at the end of the session.
     """
-    try:
-        proxy = Proxy(5577, 5578)
-        proxy_created = True
-    except ZMQError:
-        proxy = None  # Use already running proxy.
-        proxy_created = False
+    # try:
+    #     proxy = Proxy(5577, 5578)
+    #     proxy_created = True
+    # except ZMQError:
+    #     proxy = None  # Use already running proxy.
+    #     proxy_created = False
 
-    def start_proxy():
-        if proxy_created and proxy is not None:
-            proxy.start()
+    # def start_proxy():
+    #     if proxy_created and proxy is not None:
+    #         proxy.start()
 
-    # Setup dispatcher and its thread.
-    dispatcher = RemoteDispatcher("localhost:5578")
+    # # Setup dispatcher and its thread.
+    # dispatcher = RemoteDispatcher("localhost:5578")
 
-    def start_dispatcher():
-        try:
-            dispatcher.start()
-        except asyncio.exceptions.CancelledError:
-            pass  # Ignore cancellation errors on shutdown.
+    # def start_dispatcher():
+    #     try:
+    #         dispatcher.start()
+    #     except asyncio.exceptions.CancelledError:
+    #         pass  # Ignore cancellation errors on shutdown.
 
-    # Setup publisher.
-    publisher = Publisher("localhost:5577")
+    # # Setup publisher.
+    # publisher = Publisher("localhost:5577")
 
-    # Start proxy and dispatcher in daemon threads.
-    proxy_thread = Thread(target=start_proxy, daemon=True)
-    dispatcher_thread = Thread(target=start_dispatcher, daemon=True)
-    proxy_thread.start()
+    # # Start proxy and dispatcher in daemon threads.
+    # proxy_thread = Thread(target=start_proxy, daemon=True)
+    # dispatcher_thread = Thread(target=start_dispatcher, daemon=True)
+    # proxy_thread.start()
+    # dispatcher_thread.start()
+
+    ### NEW
+    port_queue = multiprocessing.Queue()
+    # Start the Proxy Process
+    # We store it as proxy_proc so we can terminate it later
+    proxy_proc = multiprocessing.Process(
+        target=run_zmq_proxy,
+        args=(port_queue,),
+        daemon=True,
+    )
+    proxy_proc.start()
+    # Give the proxy 200ms to bind to the ports
+    time.sleep(0.2)
+    # Retrieve the dynamically assigned ports
+    in_port, out_port = port_queue.get()
+    print(f"Proxy started on ports: Publisher={in_port}, Dispatcher={out_port}")
+    # Setup Publisher and Dispatcher using the dynamic ports once for all plots and measurements run from the main app.
+    # Measurements only create their own if the Python script is run 'standalone', so without the main app.
+    publisher = Publisher(f"localhost:{in_port}")
+    dispatcher = RemoteDispatcher(f"localhost:{out_port}")
+
+    # 4. Start Dispatcher in a Thread
+    # We store the thread as dispatcher_thread to join it later
+    dispatcher_thread = threading.Thread(
+        target=dispatcher.start,
+        daemon=True,
+    )
     dispatcher_thread.start()
-
     # Yield the shared objects for tests.
     yield publisher, dispatcher
 
     # Teardown: stop the proxy once all tests have finished.
-    if proxy_created and proxy is not None:
-        proxy.stop()
+    dispatcher.stop()
+    dispatcher_thread.join(timeout=1.0)
+    proxy_proc.terminate()
+    proxy_proc.join(timeout=1.0)
 
 
 @pytest.fixture(autouse=True)

--- a/nomad_camels/tests/protocol_test.py
+++ b/nomad_camels/tests/protocol_test.py
@@ -42,36 +42,6 @@ def zmq_setup():
     Yields a tuple (publisher, dispatcher) for use in tests.
     Stops the proxy at the end of the session.
     """
-    # try:
-    #     proxy = Proxy(5577, 5578)
-    #     proxy_created = True
-    # except ZMQError:
-    #     proxy = None  # Use already running proxy.
-    #     proxy_created = False
-
-    # def start_proxy():
-    #     if proxy_created and proxy is not None:
-    #         proxy.start()
-
-    # # Setup dispatcher and its thread.
-    # dispatcher = RemoteDispatcher("localhost:5578")
-
-    # def start_dispatcher():
-    #     try:
-    #         dispatcher.start()
-    #     except asyncio.exceptions.CancelledError:
-    #         pass  # Ignore cancellation errors on shutdown.
-
-    # # Setup publisher.
-    # publisher = Publisher("localhost:5577")
-
-    # # Start proxy and dispatcher in daemon threads.
-    # proxy_thread = Thread(target=start_proxy, daemon=True)
-    # dispatcher_thread = Thread(target=start_dispatcher, daemon=True)
-    # proxy_thread.start()
-    # dispatcher_thread.start()
-
-    ### NEW
     port_queue = multiprocessing.Queue()
     # Start the Proxy Process
     # We store it as proxy_proc so we can terminate it later

--- a/nomad_camels/tests/protocol_test.py
+++ b/nomad_camels/tests/protocol_test.py
@@ -102,8 +102,8 @@ def zmq_setup():
     yield publisher, dispatcher
 
     # Teardown: stop the proxy once all tests have finished.
-    dispatcher.stop()
-    dispatcher_thread.join(timeout=1.0)
+    dispatcher.loop.call_soon_threadsafe(dispatcher.loop.stop)
+    dispatcher_thread.join(timeout=2.0)
     proxy_proc.terminate()
     proxy_proc.join(timeout=1.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nomad_camels"
-version = "1.10.9"
+version = "1.11.0"
 description = "CAMELS is a configurable measurement software, targeted towards the requirements of experimental solid-state physics."
 authors = [
     {name = "FAIRmat - HU Berlin",email = "nomad-camels@fau.de"}


### PR DESCRIPTION
### 1.11.0

Fixes:
- Removed deprecated calls to `bluesky.callbacks.zmq` that broke installs when using `bluesky > 1.15.1`. Replaced with a new and cleaner implementation of the ZMQ proxy. Cleanup is also improved. ZMQ implementation for testing was adapted accordingly.